### PR TITLE
Adding disabled state for scroll buttons

### DIFF
--- a/src/AnypointTabs.js
+++ b/src/AnypointTabs.js
@@ -62,11 +62,6 @@ export class AnypointTabs extends AnypointMenubarMixin(ArcResizableMixin(LitElem
         display: none;
       }
 
-      .not-visible {
-        opacity: 0;
-        cursor: default;
-      }
-
       anypoint-icon-button {
         width: 40px;
         height: 40px;
@@ -556,9 +551,6 @@ export class AnypointTabs extends AnypointMenubarMixin(ArcResizableMixin(LitElem
     if (!scrollable || hideScrollButtons) {
       return 'hidden';
     }
-    if (isHidden) {
-      return 'not-visible';
-    }
     return '';
   }
 
@@ -579,11 +571,19 @@ export class AnypointTabs extends AnypointMenubarMixin(ArcResizableMixin(LitElem
   }
 
   _scrollToLeft() {
-    this._affectScroll(-this._step);
+    if (this._leftHidden) {
+      this._onScrollButtonUp()
+    } else {
+      this._affectScroll(-this._step);
+    }
   }
 
   _scrollToRight() {
-    this._affectScroll(this._step);
+    if (this._rightHidden) {
+      this._onScrollButtonUp()
+    } else {
+      this._affectScroll(this._step);
+    }
   }
 
   _touchMove(e) {
@@ -617,6 +617,7 @@ export class AnypointTabs extends AnypointMenubarMixin(ArcResizableMixin(LitElem
     return html`<anypoint-icon-button
       aria-label="Activate to move tabs left"
       class="${this._leftButtonClass}"
+      .disabled="${this._leftHidden}"
       @mouseup="${this._onScrollButtonUp}"
       @mousedown="${this._onLeftScrollButtonDown}" tabindex="-1">
       <svg viewBox="0 0 24 24"
@@ -635,6 +636,7 @@ export class AnypointTabs extends AnypointMenubarMixin(ArcResizableMixin(LitElem
     return html`<anypoint-icon-button
       aria-label="Activate to move tabs right"
       class="${this._rightButtonClass}"
+      .disabled="${this._rightHidden}"
       @mouseup="${this._onScrollButtonUp}"
       @mousedown="${this._onRightScrollButtonDown}" tabindex="-1">
       <svg viewBox="0 0 24 24"

--- a/test/anypoint-tabs.test.js
+++ b/test/anypoint-tabs.test.js
@@ -191,18 +191,6 @@ describe('AnypointTabs', () => {
       const element = await basicFixture();
       assert.equal(element._leftButtonClass, 'hidden');
     });
-
-    it('returns "not-visible" when _leftHidden', async () => {
-      const element = await scrollableFixture();
-      element._leftHidden = true;
-      assert.equal(element._leftButtonClass, 'not-visible');
-    });
-
-    it('returns "hidden" when _leftHidden', async () => {
-      const element = await scrollableFixture();
-      element.hideScrollButtons = true;
-      assert.equal(element._leftButtonClass, 'hidden');
-    });
   });
 
   describe('_rightButtonClass', () => {
@@ -216,18 +204,48 @@ describe('AnypointTabs', () => {
       assert.equal(element._rightButtonClass, 'hidden');
     });
 
-    it('returns "not-visible" when _rightHidden', async () => {
-      const element = await scrollableFixture();
-      element._rightHidden = true;
-      assert.equal(element._rightButtonClass, 'not-visible');
-    });
-
     it('returns "hidden" when _leftHidden', async () => {
       const element = await scrollableFixture();
       element.hideScrollButtons = true;
       assert.equal(element._rightButtonClass, 'hidden');
     });
   });
+
+  describe('_onRightScrollButtonDown', () => {
+    it('defines holdJob when scrolling right', async () => {
+      const element = await scrollableFixture()
+      element._holdJob = null
+      element._onRightScrollButtonDown()
+      assert.notEqual(element._holdJob, null)
+    })
+
+    it('clears holdJob when rightHidden is true', async () => {
+      const element = await scrollableFixture()
+      element._holdJob = null
+      element._onRightScrollButtonDown()
+      element._rightHidden = true
+      element._scrollToRight()
+      assert.equal(element._holdJob, null)
+    })
+  })
+
+  describe('_onLeftScrollButtonDown', () => {
+    it('defines holdJob when scrolling left ', async () => {
+      const element = await scrollableFixture()
+      element._holdJob = null
+      element._onLeftScrollButtonDown()
+      assert.notEqual(element._holdJob, null)
+    })
+
+    it('clears holdJob when leftHidden is true', async () => {
+      const element = await scrollableFixture()
+      element._holdJob = null
+      element._onLeftScrollButtonDown()
+      element._leftHidden = true
+      element._scrollToLeft()
+      assert.equal(element._holdJob, null)
+    })
+  })
 
   describe('_tabsContainer', () => {
     let element;


### PR DESCRIPTION
Currently, the scroll button is being hidden when it is not possible to scroll. This PR fixes this to make the button visible but in disabled state for these cases.
Before:
![image](https://user-images.githubusercontent.com/24916481/68792777-d333c580-062a-11ea-8933-31c829bd2a52.png)

After:
![image](https://user-images.githubusercontent.com/24916481/68792794-dd55c400-062a-11ea-978a-381532335c16.png)
