### PR TITLE
Tabs scroll not rendering

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,103 @@
+name: Tests and publishing
+env:
+  FORCE_COLOR: 1
+on:
+  push:
+    branches:
+      - master
+      - main
+      - develop
+      - stage
+  pull_request:
+    branches:
+      - master
+      - main
+      - stage
+jobs:
+  test_linux:
+    name: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        # os: [ubuntu-18.04, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - uses: microsoft/playwright-github-action@v1
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+  test_win:
+    name: "Windows"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - uses: microsoft/playwright-github-action@v1
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+  tag:
+    name: "Publishing release"
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+    needs:
+      - test_linux
+      - test_win
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm install
+      - name: Read version from package.json
+        uses: culshaw/read-package-node-version-actions@v1
+        id: package-node-version
+      - name: Changelog
+        uses: scottbrenner/generate-changelog-action@master
+        id: Changelog
+      - name: Github Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.package-node-version.outputs.version }}
+          release_name: v${{ steps.package-node-version.outputs.version }}
+          body: |
+            ${{ steps.Changelog.outputs.changelog }}
+          draft: false
+          prerelease: false
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}%

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tabs organize content across different screens, data sets, and other interaction
 
 [![Published on NPM](https://img.shields.io/npm/v/@anypoint-web-components/anypoint-tabs.svg)](https://www.npmjs.com/package/@anypoint-web-components/anypoint-tabs)
 
-[![Tests and publishing](https://github.com/anypoint-web-components/anypoint-tabs/actions/workflows/deployment.yml/badge.svg)](https://github.com/anypoint-web-components/anypoint-tabs/actions/workflows/deployment.yml)
+[![tests](https://github.com/anypoint-web-components/anypoint-tabs/actions/workflows/tests.yml/badge.svg)](https://github.com/anypoint-web-components/anypoint-tabs/actions/workflows/tests.yml)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tabs organize content across different screens, data sets, and other interaction
 
 [![Published on NPM](https://img.shields.io/npm/v/@anypoint-web-components/anypoint-tabs.svg)](https://www.npmjs.com/package/@anypoint-web-components/anypoint-tabs)
 
-[![tests](https://github.com/anypoint-web-components/anypoint-tabs/actions/workflows/tests.yml/badge.svg)](https://github.com/anypoint-web-components/anypoint-tabs/actions/workflows/tests.yml)
+[![Tests and publishing](https://github.com/anypoint-web-components/anypoint-tabs/actions/workflows/deployment.yml/badge.svg)](https://github.com/anypoint-web-components/anypoint-tabs/actions/workflows/deployment.yml)
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@anypoint-web-components/anypoint-tabs",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anypoint-web-components/anypoint-tabs",
   "description": "Accessible tabs styled for Material Design and Anypoint platform",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/AnypointTabs.js
+++ b/src/AnypointTabs.js
@@ -342,7 +342,7 @@ export class AnypointTabs extends MenubarMixin(ArcResizableMixin(LitElement)) {
 
   _affectScrollButton() {
     const { scrollWidth, clientWidth } = this._tabsContainer;
-    const shouldHideButtons = scrollWidth >= clientWidth
+    const shouldHideButtons = scrollWidth <= clientWidth
     if (shouldHideButtons !== this.hideScrollButtons) {
       this.hideScrollButtons = shouldHideButtons;
     }

--- a/test/anypoint-tabs.test.js
+++ b/test/anypoint-tabs.test.js
@@ -2,7 +2,8 @@ import {
   html,
   fixture,
   assert,
-  aTimeout
+  aTimeout,
+  nextFrame
 } from '@open-wc/testing';
 import * as MockInteractions from '@polymer/iron-test-helpers/mock-interactions.js';
 import '../anypoint-tabs.js';
@@ -505,6 +506,28 @@ describe('AnypointTabs', () => {
       e.changedTouches = touches;
       tab.dispatchEvent(e);
       assert.equal(element.__lastTouchX, 0);
+    });
+  });
+
+  describe('Hiding scroll', () => {
+    let element = (null)
+
+    it('should hide arrows when there are not enough tabs to scroll', async () => {
+      element = await scrollableFixture(3)
+      element.hideScrollButtons = true;
+      await nextFrame();
+      element.style.width = '500px';
+      await nextFrame();
+      assert.isNotEmpty(element.shadowRoot.querySelectorAll('anypoint-icon-button.hidden'))
+    });
+
+    it('should show arrows when the element\'s width decreases enough', async () => {
+      element = await scrollableFixture(3)
+      element.hideScrollButtons = true;
+      await nextFrame();
+      element.style.width = '100px';
+      await nextFrame()
+      assert.isEmpty(element.shadowRoot.querySelectorAll('anypoint-icon-button.hidden'))
     });
   });
 });

--- a/test/anypoint-tabs.test.js
+++ b/test/anypoint-tabs.test.js
@@ -526,7 +526,7 @@ describe('AnypointTabs', () => {
       element.hideScrollButtons = true;
       await nextFrame();
       element.style.width = '100px';
-      await nextFrame()
+      await aTimeout(100);
       assert.isEmpty(element.shadowRoot.querySelectorAll('anypoint-icon-button.hidden'))
     });
   });


### PR DESCRIPTION
When allowing to hide the scroll, the arrows do not appear once the scroll width has become smaller than the client width.